### PR TITLE
Add port id to port name to avoid collisions

### DIFF
--- a/port.c
+++ b/port.c
@@ -116,10 +116,11 @@ a2j_port_fill_name(
     ret = snprintf(
       port_ptr->name,
       g_max_jack_port_name_size,
-      "%s [%d] (%s): %s",
+      "%s [%d] (%s): [%d] %s",
       snd_seq_client_info_get_name(client_info_ptr),
       snd_seq_client_info_get_client(client_info_ptr),
       type == A2J_PORT_CAPTURE ? "capture": "playback",
+      snd_seq_port_info_get_port(port_info_ptr),
       snd_seq_port_info_get_name(port_info_ptr));
   }
   else


### PR DESCRIPTION
This patch changes the pattern how jack port names are derived from alsa
port names when using unique port names. It adds the port id after the
':' to make sure port names are really unique, even when the alsa ports
are not (or too long).
This fixes problems with the ploytec gm5 which has up to 5 in/out ports
and quite long client/port names.