### PR TITLE
sigsegv: enable RISC-V build

### DIFF
--- a/sigsegv.c
+++ b/sigsegv.c
@@ -91,7 +91,9 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
     a2j_error("info.si_errno = %d", info->si_errno);
     a2j_error("info.si_code  = %d (%s)", info->si_code, si_codes[info->si_code]);
     a2j_error("info.si_addr  = %p", info->si_addr);
-#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__)
+#if !defined(__alpha__) && !defined(__ia64__) && \
+    !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && \
+    !defined(__sh__) && !defined(__aarch64__) && !defined(__riscv)
     for(i = 0; i < NGREG; i++)
         a2j_error("reg[%02d]       = 0x" REGFORMAT, i,
 #if defined(__powerpc__) && !defined(__powerpc64__)
@@ -108,7 +110,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
                 ucontext->uc_mcontext.gregs[i]
 #endif
                 );
-#endif /* alpha, ia64, kFreeBSD, arm, hppa, aarch64 */
+#endif /* alpha, ia64, kFreeBSD, arm, hppa, aarch64, riscv */
 
 #if defined(SIGSEGV_STACK_X86) || defined(SIGSEGV_STACK_IA64)
 # if defined(SIGSEGV_STACK_IA64)


### PR DESCRIPTION
Avoid build error

../sigsegv.c:104:39: error: ‘mcontext_t’ has no member named ‘gregs’;
did you mean ‘__gregs’?
  104 |                 ucontext->uc_mcontext.gregs[i]
      |                                       ^~~~~

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>