### PR TITLE
sigsegv.c: enable build for LoongArch

### DIFF
--- a/sigsegv.c
+++ b/sigsegv.c
@@ -91,7 +91,9 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
     a2j_error("info.si_errno = %d", info->si_errno);
     a2j_error("info.si_code  = %d (%s)", info->si_code, si_codes[info->si_code]);
     a2j_error("info.si_addr  = %p", info->si_addr);
-#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__)
+#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && \
+    !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && \
+    !defined(__aarch64__) && !defined(__loongarch__)
     for(i = 0; i < NGREG; i++)
         a2j_error("reg[%02d]       = 0x" REGFORMAT, i,
 #if defined(__powerpc__) && !defined(__powerpc64__)
@@ -108,7 +110,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
                 ucontext->uc_mcontext.gregs[i]
 #endif
                 );
-#endif /* alpha, ia64, kFreeBSD, arm, hppa, aarch64 */
+#endif /* alpha, ia64, kFreeBSD, arm, hppa, aarch64, loongarch */
 
 #if defined(SIGSEGV_STACK_X86) || defined(SIGSEGV_STACK_IA64)
 # if defined(SIGSEGV_STACK_IA64)


### PR DESCRIPTION
When compiling the package  a2jmidid for loong64 in the Debian Package Auto-Building environment [1], The error message is as follows:
../sigsegv.c: In function ‘signal_segv’:
../sigsegv.c:97:20: error: ‘NGREG’ undeclared (first use in this function)
   97 |     for(i = 0; i < NGREG; i++)
      |                    ^~~~~
../sigsegv.c:97:20: note: each undeclared identifier is reported only once for each function it appears in
In file included from ../sigsegv.c:39:
../sigsegv.c:106:39: error: ‘mcontext_t’ has no member named ‘gregs’; did you mean ‘__gregs’?
  106 |                 ucontext->uc_mcontext.gregs[i]
      |                                       ^~~~~
../log.h:47:134: note: in definition of macro ‘a2j_error’

Please review. 
If you have any questions, you can contact me at any time.


[1]:https://buildd.debian.org/status/package.php?p=a2jmidid&suite=sid