### PR TITLE
Add support for loongarch64 build

### DIFF
--- a/sigsegv.c
+++ b/sigsegv.c
@@ -91,7 +91,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
     a2j_error("info.si_errno = %d", info->si_errno);
     a2j_error("info.si_code  = %d (%s)", info->si_code, si_codes[info->si_code]);
     a2j_error("info.si_addr  = %p", info->si_addr);
-#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__)
+#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__) && !defined(__loongarch64)
     for(i = 0; i < NGREG; i++)
         a2j_error("reg[%02d]       = 0x" REGFORMAT, i,
 #if defined(__powerpc__) && !defined(__powerpc64__)
@@ -108,7 +108,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
                 ucontext->uc_mcontext.gregs[i]
 #endif
                 );
-#endif /* alpha, ia64, kFreeBSD, arm, hppa, aarch64 */
+#endif /* alpha, ia64, kFreeBSD, arm, hppa, aarch64, loongarch64 */
 
 #if defined(SIGSEGV_STACK_X86) || defined(SIGSEGV_STACK_IA64)
 # if defined(SIGSEGV_STACK_IA64)


### PR DESCRIPTION
LoongArch is a new RISC ISA developed by Loongson, which is a bit like MIPS or RISC-V. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.

I've added definitions in `sigsegv.c` to support LoongArch64.

I've tested my patch for LoongArch64's Arch Linux port:  
**Success** [View log](https://gist.github.com/RealRoller233/3b6124bf5ea3d690f11aede9d1a2d4d9)