### PR TITLE
Update sigsegv.c: enable riscv64 and loong64 building

### DIFF
--- a/sigsegv.c
+++ b/sigsegv.c
@@ -91,7 +91,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
     a2j_error("info.si_errno = %d", info->si_errno);
     a2j_error("info.si_code  = %d (%s)", info->si_code, si_codes[info->si_code]);
     a2j_error("info.si_addr  = %p", info->si_addr);
-#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__)
+#if !defined(__alpha__) && !defined(__ia64__) && !defined(__FreeBSD_kernel__) && !defined(__arm__) && !defined(__hppa__) && !defined(__sh__) && !defined(__aarch64__) && !defined(__riscv) && !defined(__loongarch__)
     for(i = 0; i < NGREG; i++)
         a2j_error("reg[%02d]       = 0x" REGFORMAT, i,
 #if defined(__powerpc__) && !defined(__powerpc64__)
@@ -108,7 +108,7 @@ static void signal_segv(int signum, siginfo_t* info, void*ptr) {
                 ucontext->uc_mcontext.gregs[i]
 #endif
                 );
-#endif /* alpha, ia64, kFreeBSD, arm, hppa, aarch64 */
+#endif /* alpha, ia64, kFreeBSD, arm, hppa, aarch64, riscv, loongarch */
 
 #if defined(SIGSEGV_STACK_X86) || defined(SIGSEGV_STACK_IA64)
 # if defined(SIGSEGV_STACK_IA64)


### PR DESCRIPTION
Based on patches from:
Heinrich Schuchardt <heinrich.schuchardt@canonical.com> sigsegv: enable RISC-V build
And:
hangdandan <zhangdandan@loongson.cn>
Add support for loongarch